### PR TITLE
[125] Add --random-wallet flag

### DIFF
--- a/cmd/mine.go
+++ b/cmd/mine.go
@@ -23,7 +23,9 @@ package cmd
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/Noso-Project/noso-go/internal/miner"
 	"github.com/spf13/cobra"
@@ -51,6 +53,12 @@ Example usage:
 			os.Exit(1)
 		}
 
+		if randomize, _ := cmd.Flags().GetBool("random-wallet"); randomize {
+			w := mineOpts.Wallets
+			rand.Seed(time.Now().UnixNano())
+			rand.Shuffle(len(w), func(i, j int) { w[i], w[j] = w[j], w[i] })
+		}
+
 		ipAddr, err := lookupIP(mineOpts.IpAddr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not get IP address for domain: %v\n", err)
@@ -73,6 +81,7 @@ func init() {
 	mineCmd.Flags().BoolVarP(&mineOpts.ShowPop, "show-pop", "", false, "Show PoP solutions in output")
 	mineCmd.Flags().IntVar(&mineOpts.StatusInterval, "status-interval", 60, "Status Interval Timer (in seconds)")
 	mineCmd.Flags().BoolVarP(&mineOpts.ExitOnRetry, "exit-on-retry", "", false, "Quit noso-go if pool connection is lost")
+	mineCmd.Flags().BoolP("random-wallet", "", false, "Randomize order wallets are used")
 
 	mineCmd.MarkFlagRequired("address")
 	mineCmd.MarkFlagRequired("password")

--- a/cmd/pool.go
+++ b/cmd/pool.go
@@ -24,9 +24,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Noso-Project/noso-go/internal/miner"
 	"github.com/spf13/cobra"
@@ -97,6 +99,12 @@ Start mining with a pool
 			os.Exit(1)
 		}
 
+		if randomize, _ := cmd.Flags().GetBool("random-wallet"); randomize {
+			w := poolOpts.Wallets
+			rand.Seed(time.Now().UnixNano())
+			rand.Shuffle(len(w), func(i, j int) { w[i], w[j] = w[j], w[i] })
+		}
+
 		if poolOpts.Cpu < 1 {
 			cmd.PrintErrln("Error: --cpu cannot be less than 1")
 			os.Exit(1)
@@ -126,6 +134,7 @@ func init() {
 	poolCmd.Flags().BoolVarP(&poolOpts.ShowPop, "show-pop", "", false, "Show PoP solutions in output")
 	poolCmd.Flags().IntVar(&poolOpts.StatusInterval, "status-interval", 60, "Status Interval Timer (in seconds)")
 	poolCmd.Flags().BoolVarP(&poolOpts.ExitOnRetry, "exit-on-retry", "", false, "Quit noso-go if pool connection is lost")
+	poolCmd.Flags().BoolP("random-wallet", "", false, "Randomize order wallets are used")
 
 	poolCmd.Flags().SortFlags = false
 	poolCmd.Flags().PrintDefaults()


### PR DESCRIPTION
 - Closes #125
 - Adds `--random-wallet` flag to `mine` and `mine pool` verbs
 - `--random-wallet` will make the miner randomize the order of wallets
   in use before mining is started